### PR TITLE
LogCombiner takes a list of inputs

### DIFF
--- a/workflows/beast/modules/LogCombiner/config/config.yaml
+++ b/workflows/beast/modules/LogCombiner/config/config.yaml
@@ -9,10 +9,8 @@ params:
   strip: false
   renumber: false
   input:
-    infile1: "run-1.log"
-    infile2: "run-2.log"
-    infile3: null
-    infile4: null
-    infile5: null
+    infiles:
+      - "run-1.log"
+      - "run-2.log"
   output:
     outfile: "combined.log"

--- a/workflows/beast/modules/LogCombiner/workflow/Snakefile
+++ b/workflows/beast/modules/LogCombiner/workflow/Snakefile
@@ -1,6 +1,6 @@
 """LogCombiner-BEAST1
 
-This module takes multiple (up to 5) log or tree files from BEAST (v1.10.4/5) as input and returns a single combined log or tree file as output.
+This module takes multiple log or tree files from BEAST (v1.10.4/5) as input and returns a single combined log or tree file as output.
 
 Params:
     trees (boolean): use this option to combine tree log files (default is false)
@@ -11,11 +11,7 @@ Params:
     strip (boolean): strip out all annotations (trees only)
     renumber (boolean): this option renumbers output states consecutively
     input:
-        infile1 (string): input log/tree file 1
-        infile2 (string): input log/tree file 2
-        infile3 (string): input log/tree file 3
-        infile4 (string): input log/tree file 4
-        infile5 (string): input log/tree file 5
+        infiles (list of strings): input log/tree files
     output:
         outfile (string): output combined log/tree file
 """
@@ -28,30 +24,10 @@ params=config["params"]
 
 rule target:
     input:
-        infile1 = expand(
+        infile = expand(
             "results/{indir}/{filename}",
             indir=indir,
-            filename=params["input"]["infile1"]
-        ),
-        infile2 = expand(
-            "results/{indir}/{filename}",
-            indir=indir,
-            filename=params["input"]["infile2"]
-        ),
-        infile3 = expand(
-            "results/{indir}/{filename}",
-            indir=indir,
-            filename=params["input"]["infile3"]
-        ),
-        infile4 = expand(
-            "results/{indir}/{filename}",
-            indir=indir,
-            filename=params["input"]["infile4"]
-        ),
-        infile5 = expand(
-            "results/{indir}/{filename}",
-            indir=indir,
-            filename=params["input"]["infile5"]
+            filename=params["input"]["infiles"]
         ),
     output:
         outfile = expand(
@@ -79,5 +55,5 @@ rule target:
             -scale {params.scale} \
             $(if [ {params.strip} == true ]; then echo "-strip"; else echo ""; fi) \
             $(if [ {params.renumber} == true ]; then echo "-renumber"; else echo ""; fi) \
-            {input.infile1} {input.infile2} {input.infile3} {input.infile4} {input.infile5} {output.outfile}
+            {input.infile} {output.outfile}
         """


### PR DESCRIPTION
I have modified LogCombiner so that it takes a list of filenames as input, instead of 5 filenames (some of which could be null). This was primarily because Snakemake complained of not being able to find a rule to generate `results/out/None` (corresponding to the null inputs). This approach is also more generalisable, relying on Snakemake's `expand` function to process an arbitrary length list of input files into one output.

The workflow was tested by copying the `resources/example_input` folder to `results/in` and running with default parameters (on my Mac this required: `CONDA_SUBDIR=osx-64 snakemake --cores 1 --use-conda`).

The output of the test is displayed below:
```
               LogCombiner v1.10.4, 2002-2018
                    MCMC Output Combiner
                             by
           Andrew Rambaut and Alexei J. Drummond

             Institute of Evolutionary Biology
                  University of Edinburgh
                     a.rambaut@ed.ac.uk

               Department of Computer Science
                   University of Auckland
                  alexei@cs.auckland.ac.nz


Creating combined log file: 'results/out/combined.log'
Rescaling using scale factor: 1.0


Combining file: 'results/in/run-1.log' removing burnin: 1000000, resampling with frequency: 10000, rescaling by: 1.0
Combining file: 'results/in/run-2.log' removing burnin: 1000000, resampling with frequency: 10000, rescaling by: 1.0
Finished.
```

This produces a file `results/out/combined.log` which was approximately the size of the two input logs combined.